### PR TITLE
Ignore splitting separators inside parenthesis & minor stuff

### DIFF
--- a/lb_matching_tools/cleaner.py
+++ b/lb_matching_tools/cleaner.py
@@ -45,7 +45,7 @@ class MetadataCleaner:
         text = self.drop_foreign_chars(text)
 
         for i, exp in enumerate(self.recording_expressions):
-            m = self.recording_expressions[i].match(text)
+            m = exp.match(text)
             if m is not None:
                 cleaned = m.groups()[0]
 
@@ -67,7 +67,7 @@ class MetadataCleaner:
             return cleaned
 
         for i, exp in enumerate(self.artist_expressions):
-            m = self.artist_expressions[i].match(text)
+            m = exp.match(text)
             if m is not None:
                 return m.groups()[0]
 

--- a/lb_matching_tools/cleaner.py
+++ b/lb_matching_tools/cleaner.py
@@ -50,6 +50,7 @@ class MetadataCleaner:
                 cleaned = m.groups()[0]
 
                 # This is ugly.
+                # Could be avoided by using a list of keywords which indicate crap and e.g. baking them into a lookahead expression.
                 if i == 2:
                     if hyphen_split_check(text, cleaned):
                         return cleaned

--- a/lb_matching_tools/cleaner.py
+++ b/lb_matching_tools/cleaner.py
@@ -21,10 +21,7 @@ class MetadataCleaner:
         r"(?P<title>.+?)\s+?(?P<feat>[\[\(]?(?:feat(?:uring)?|ft)\b\.?)\s*?(?P<artists>.+)\s*",
 
         # Don't Give up - 2001 remaster
-        r"(?P<title>.+?)(?:\s+?[\u2010\u2012\u2013\u2014~/-])(?P<dash>.*)",
-
-        # Kikagaku Moyo/幾何学模様
-        r"(?P<title>.+?)(?:\s*?[~/])(?P<dash>.*)",
+        r"(?P<title>.+?)(?:\s+?[\u2010\u2012\u2013\u2014~/-])(?![^(]*\))(?P<dash>.*)",
     ]
 
     ARTIST_EXPRESSIONS = [

--- a/lb_matching_tools/tests/test_cleaner.py
+++ b/lb_matching_tools/tests/test_cleaner.py
@@ -23,7 +23,8 @@ TEST_STRINGS = [
     ("recording", "Philip the Chancelor: Clavus pungens — 2vv conductus", "Philip the Chancelor: Clavus pungens"), # em dash
     ("recording", '"Beckoning Darkness" ~ Menu', '"Beckoning Darkness"'),
     ("recording", 'Big Phat at Glen Echo, MD Contradance / CALLER: Ridge Kennedy', 'Big Phat at Glen Echo, MD Contradance'),
-    ("recording", 'Kikagaku Moyo/幾何学模様', 'Kikagaku Moyo'),
+    # Trailing punctuation (or punctuation in general) can be discarded in a consecutive step
+    ("recording", 'Kikagaku Moyo/幾何学模様', 'Kikagaku Moyo/'),
     ("recording", '山地情歌 San-Di Love Song', 'San-Di Love Song'),
     ("recording", 'Madness (DJ Gollum feat. DJ Cap Remix)', 'Madness'),
     ("recording", 'Other Place [Live]', 'Other Place'),


### PR DESCRIPTION
In addition to adding a negative lookahead to the relevant expression, this would have required to also adapt the following expression.
Since that one is pretty much redundant and covers only one case, I've decided to drop it instead and relax the corresponding test case to allow trailing punctuation which can be discarded in a consecutive step.

Plus a minor refactoring and documentation of a possible (future) improvement.